### PR TITLE
Bitshift will give wrong result when sizeof(UdmSize_t) == 4.

### DIFF
--- a/include/udm_memutils.h
+++ b/include/udm_memutils.h
@@ -55,9 +55,15 @@ inline int udm_set_entryid(DATA_TYPE *ids, UdmSize_t id, int rankno, int num_ent
             ids[n++] = rankno;
         }
         else if (sizeof(DATA_TYPE) < sizeof(UdmSize_t)) {
+#ifdef UDM_SIZE64
             ids[n++] = (DATA_TYPE)(id >> 32);
             ids[n++] = (DATA_TYPE)(id & 0xFFFFFFFF);
             ids[n++] = rankno;
+#else
+            ids[n++] = (DATA_TYPE)id;
+            ids[n++] = 0;
+            ids[n++] = rankno;
+#endif
         }
     }
     else {
@@ -95,8 +101,13 @@ inline int udm_get_entryid(DATA_TYPE *ids, UdmSize_t &id, int &rankno, int num_e
             rankno = ids[2];
         }
         else if (sizeof(DATA_TYPE) < sizeof(UdmSize_t)) {
+#ifdef UDM_SIZE64
             id = ((UdmSize_t)ids[0] << 32) | ids[1];
             rankno = ids[2];
+#else
+            id = ids[0];
+            rankno = ids[2];
+#endif
         }
     }
     else {


### PR DESCRIPTION
This patch will fix such a case.
