### PR TITLE
Fix the build error when compiling with ICC.

### DIFF
--- a/examples/cc/cgns/create_cgns.c
+++ b/examples/cc/cgns/create_cgns.c
@@ -11,13 +11,13 @@
  * 6面体CGNSモデルを作成する.
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include "udmlib.h"
 
 #define VOXEL_I_SIZE        32

--- a/examples/cc/cgns/create_multi.c
+++ b/examples/cc/cgns/create_multi.c
@@ -11,13 +11,13 @@
  * プロセス毎に内部境界を持つ6面体CGNSモデルを作成する.
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include "udmlib.h"
 
 #ifdef __cplusplus

--- a/examples/cc/cgns/read_cgns.c
+++ b/examples/cc/cgns/read_cgns.c
@@ -11,10 +11,10 @@
  * CGNSファイルを読み込む。
  */
 
+#include "udmlib.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include "udmlib.h"
 
 #ifdef __cplusplus
 using namespace udm;

--- a/examples/cc/cgns/user_defined.c
+++ b/examples/cc/cgns/user_defined.c
@@ -12,9 +12,9 @@
  */
 
 
+#include <udmlib.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <udmlib.h>
 
 #ifdef __cplusplus
 using namespace udm;

--- a/examples/cc/cgns/vtk2cgns.c
+++ b/examples/cc/cgns/vtk2cgns.c
@@ -12,10 +12,10 @@
  */
 
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdio.h>
 #include <string.h>
-#include <mpi.h>
 #include <udmlib.h>
 
 #ifdef __cplusplus

--- a/examples/cc/dfi/dfi_unit.c
+++ b/examples/cc/dfi/dfi_unit.c
@@ -12,9 +12,9 @@
  * @file dfi_unit.c
  */
 
+#include <udmlib.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <udmlib.h>
 
 #ifdef __cplusplus
 using namespace udm;

--- a/examples/cc/partition/partition.c
+++ b/examples/cc/partition/partition.c
@@ -10,11 +10,11 @@
  * @file partition.c
  * CGNSモデルの分割
  */
+#include <mpi.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include "udmlib.h"
 
 #ifdef __cplusplus

--- a/examples/cc/partition/partition_solutions.c
+++ b/examples/cc/partition/partition_solutions.c
@@ -11,10 +11,10 @@
  * 物理量を持つCGNSモデルの分割
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <math.h>
-#include <mpi.h>
 #include <udmlib.h>
 
 #ifdef __cplusplus

--- a/examples/cc/partition/partition_weight.c
+++ b/examples/cc/partition/partition_weight.c
@@ -11,9 +11,9 @@
  * CGNSモデルの重みを持つ分割
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <udmlib.h>
 
 #ifdef __cplusplus

--- a/examples/cc/timeslice/create_timeslice.c
+++ b/examples/cc/timeslice/create_timeslice.c
@@ -11,11 +11,11 @@
  * TimeSlice出力のFileCompositionTypeを設定する.
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
-#include <mpi.h>
 #include "udmlib.h"
 
 #ifdef __cplusplus

--- a/examples/cc/timeslice/timeslice.c
+++ b/examples/cc/timeslice/timeslice.c
@@ -11,11 +11,11 @@
  * 時系列CGNSファイルの出力
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <math.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <udmlib.h>
 
 #ifdef __cplusplus

--- a/examples/cxx/cgns/create_cgns.cpp
+++ b/examples/cxx/cgns/create_cgns.cpp
@@ -11,6 +11,7 @@
  * 6面体CGNSモデルを作成する.
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
@@ -18,7 +19,6 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include "udmlib.h"
 #include "model/UdmModel.h"
 

--- a/examples/cxx/cgns/create_multi.cpp
+++ b/examples/cxx/cgns/create_multi.cpp
@@ -11,6 +11,7 @@
  * プロセス毎に内部境界を持つ6面体CGNSモデルを作成する.
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
@@ -18,7 +19,6 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include "udmlib.h"
 #include "model/UdmModel.h"
 

--- a/examples/cxx/cgns/read_cgns.cpp
+++ b/examples/cxx/cgns/read_cgns.cpp
@@ -11,10 +11,10 @@
  * CGNSファイルを読み込む。
  */
 
+#include <udmlib.h>
 #include <stdio.h>
 #include <iostream>
 #include <sys/stat.h>
-#include <udmlib.h>
 #include <model/UdmModel.h>
 #include <model/UdmZone.h>
 #include <model/UdmFlowSolutions.h>

--- a/examples/cxx/cgns/user_defined.cpp
+++ b/examples/cxx/cgns/user_defined.cpp
@@ -12,10 +12,10 @@
  */
 
 
+#include <udmlib.h>
 #include <stdio.h>
 #include <iostream>
 #include <sys/stat.h>
-#include <udmlib.h>
 #include <model/UdmModel.h>
 
 using namespace std;

--- a/examples/cxx/cgns/vtk2cgns.cpp
+++ b/examples/cxx/cgns/vtk2cgns.cpp
@@ -12,10 +12,10 @@
  */
 
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdio.h>
 #include <string.h>
-#include <mpi.h>
 #include <udmlib.h>
 #include <model/UdmModel.h>
 

--- a/examples/cxx/dfi/dfi_unit.cpp
+++ b/examples/cxx/dfi/dfi_unit.cpp
@@ -12,10 +12,10 @@
  * @file dfi_unit.cpp
  */
 
+#include <udmlib.h>
 #include <stdio.h>
 #include <iostream>
 #include <sys/stat.h>
-#include <udmlib.h>
 #include <model/UdmModel.h>
 
 using namespace std;

--- a/examples/cxx/partition/partition.cpp
+++ b/examples/cxx/partition/partition.cpp
@@ -10,12 +10,12 @@
  * @file partition.cpp
  * CGNSモデルの分割
  */
+#include <mpi.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <udmlib.h>
 #include <model/UdmModel.h>
 

--- a/examples/cxx/partition/partition_solutions.cpp
+++ b/examples/cxx/partition/partition_solutions.cpp
@@ -11,11 +11,11 @@
  * 物理量を持つCGNSモデルの分割
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <iostream>
 #include <sys/stat.h>
 #include <math.h>
-#include <mpi.h>
 #include <udmlib.h>
 #include <model/UdmModel.h>
 

--- a/examples/cxx/partition/partition_weight.cpp
+++ b/examples/cxx/partition/partition_weight.cpp
@@ -11,10 +11,10 @@
  * CGNSモデルの重みを持つ分割
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <iostream>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <udmlib.h>
 #include <model/UdmModel.h>
 

--- a/examples/cxx/timeslice/create_timeslice.cpp
+++ b/examples/cxx/timeslice/create_timeslice.cpp
@@ -11,12 +11,12 @@
  * TimeSlice出力のFileCompositionTypeを設定する.
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
 #include <string.h>
 #include <getopt.h>
-#include <mpi.h>
 #include "udmlib.h"
 #include "model/UdmModel.h"
 

--- a/examples/cxx/timeslice/timeslice.cpp
+++ b/examples/cxx/timeslice/timeslice.cpp
@@ -11,12 +11,12 @@
  * 時系列CGNSファイルの出力
  */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <iostream>
 #include <math.h>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <udmlib.h>
 #include <model/UdmModel.h>
 

--- a/include/UdmBase.h
+++ b/include/UdmBase.h
@@ -14,6 +14,8 @@
  * UDMlibライブラリのすべてのクラスの基底クラスのヘッダーファイル
  */
 
+#include "udmlib.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -29,7 +31,6 @@
 #include <limits>
 #include "UdmErrorHandler.h"
 #include "utils/UdmStopWatch.h"
-#include "udmlib.h"
 #include "udm_memutils.h"
 #include "udm_define.h"
 

--- a/include/config/UdmConfigBase.h
+++ b/include/config/UdmConfigBase.h
@@ -9,8 +9,8 @@
 #ifndef _UDMCONFIGBASE_H_
 #define _UDMCONFIGBASE_H_
 
-#include <TextParser.h>
 #include "UdmBase.h"
+#include <TextParser.h>
 
 /**
  * @file UdmConfigDefine.h

--- a/include/udm_mpiutils.h
+++ b/include/udm_mpiutils.h
@@ -15,10 +15,6 @@
 #ifndef _UDM_MPIUTILS_H_
 #define _UDM_MPIUTILS_H_
 
-#include <stdio.h>
-#include <stdlib.h>
-#include "udm_define.h"
-#include "udm_errorno.h"
 #ifndef WITHOUT_MPI
 #include <mpi.h>
 #else
@@ -98,6 +94,12 @@ typedef int MPI_Op;
 #define MPI_NO_OP   (MPI_Op)(0x5800000e)
 
 #endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "udm_define.h"
+#include "udm_errorno.h"
 
 #ifdef __cplusplus
 namespace udm {

--- a/include/udm_strutils.h
+++ b/include/udm_strutils.h
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <ctype.h>
 
 #ifdef __cplusplus
 namespace udm {

--- a/include/udmlib.h
+++ b/include/udmlib.h
@@ -14,10 +14,11 @@
 #ifndef _UDMLIB_H_
 #define _UDMLIB_H_
 
+#include "udm_mpiutils.h"
+
 #include "udm_errorno.h"
 #include "udm_pathutils.h"
 #include "udm_version.h"
-#include "udm_mpiutils.h"
 #include "udm_define.h"
 #include "udm_strutils.h"
 

--- a/src/UdmErrorHandler.cpp
+++ b/src/UdmErrorHandler.cpp
@@ -11,13 +11,13 @@
  * エラーハンドラクラスのソースファイル
  */
 
+#include "UdmErrorHandler.h"
 #if defined(_WIN32) && !defined(__NUTC__)
 #include <windows.h>
 #else
 #include <sys/types.h>
 #include <unistd.h>
 #endif
-#include "UdmErrorHandler.h"
 
 namespace udm
 {

--- a/src/config/UdmFileInfoConfig.cpp
+++ b/src/config/UdmFileInfoConfig.cpp
@@ -10,13 +10,13 @@
  * @file UdmFileInfo.cpp
  * index.dfiファイルのFileInfoデータクラスのソースファイル
  */
+#include "config/UdmFileInfoConfig.h"
 #include <errno.h>
 #if defined(_WIN32)
 #include <direct.h>
 #else
 #include <sys/stat.h>
 #endif
-#include "config/UdmFileInfoConfig.h"
 
 namespace udm {
 

--- a/src/config/UdmUnitListConfig.cpp
+++ b/src/config/UdmUnitListConfig.cpp
@@ -12,8 +12,8 @@
  * UdmUnitConfig, UdmUnitListConfigクラスのソースファイル
  */
 
-#include "TextParserTree.h"
 #include "config/UdmUnitListConfig.h"
+#include "TextParserTree.h"
 
 namespace udm {
 

--- a/tools/udm-frm/include/UdmStaging.h
+++ b/tools/udm-frm/include/UdmStaging.h
@@ -14,6 +14,7 @@
 #ifndef _UDMSTAGING_H_
 #define _UDMSTAGING_H_
 
+#include "model/UdmModel.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,7 +24,6 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "model/UdmModel.h"
 
 #define UDMFRM_OUTPUT_RANKFORMAT            "%06d"
 #define UDMFRM_NUM_TIMESLICE_DIRECTORY      10

--- a/tools/udm-frm/src/udm_frm.cpp
+++ b/tools/udm-frm/src/udm_frm.cpp
@@ -11,11 +11,11 @@
  * @brief  main関数
  */
 
+#include <udmlib.h>
 #include <stdio.h>
 #include <iostream>
 #include <getopt.h>
 #include <sys/stat.h>
-#include <udmlib.h>
 #include <model/UdmModel.h>
 #include "UdmStaging.h"
 #include "udmfrm_version.h"


### PR DESCRIPTION
This patch fixes the build with Intel ICC + MPI environment.

Reorder mpi.h header file inclusion to solve the following compilation error.

```
/usr/local/intel/impi/4.1.0.024/intel64/include/mpicxx.h(95): catastrophic error: #error directive: "SEEK_SET is #defined but must not
be for the C++ binding of MPI. Include mpi.h before stdio.h"
```
