### PR TITLE
ctypes.h(cctype) is required for isdigit() and tolower() definitions.

### DIFF
--- a/include/udm_strutils.h
+++ b/include/udm_strutils.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <ctype.h>
 
 #ifdef __cplusplus
 namespace udm {


### PR DESCRIPTION
Recent compiler(e.g. gcc on macOS Sierra) claims the following undeclared errors.
Including `ctypes.h` is required.

```
../../include/udm_strutils.h:42:14: error: use of undeclared identifier 'isdigit'
        if ( isdigit(str[i]) == 0 ) return false;
             ^
../../include/udm_strutils.h:60:13: error: use of undeclared identifier 'tolower'
        c = tolower((unsigned char)c);
            ^
../../include/udm_strutils.h:66:28: error: use of undeclared identifier 'tolower'
            } while ((char)tolower((unsigned char)sc) != c);
```